### PR TITLE
Add common spec and run validation against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # CHANGELOG
 Changelog for ecszap
 
-## 0.2.0 (unreleased)
+## unreleased
+
+### Bug Fixes
+* Do not allow configuration of `@timestamp`, instead always set format to ISO8601 [pull#23](https://github.com/elastic/ecs-logging-go-zap/pull/23)
+
+## 0.3.0
+
+### Enhancement
+* Update ECS version to 1.6.0 [pull#17](https://github.com/elastic/ecs-logging-go-zap/pull/17)
+
+## 0.2.0
 
 ### Enhancement
 * Add `ecszap.ECSCompatibleEncoderConfig` for making existing encoder config ECS conformant [pull#12](https://github.com/elastic/ecs-logging-go-zap/pull/12)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Following fields will be added by default:
 ```
 {
     "log.level":"info",
-    "@timestamp":1583748236254129,
+    "@timestamp":"2020-09-13T10:48:03.000Z",
     "message":"some logging info",
     "ecs.version":"1.6.0"
 }
@@ -56,7 +56,7 @@ logger.Info("some logging info",
 	// Log Output:
 	//{
 	//	"log.level":"info",
-	//	"@timestamp":1584716847523456,
+	//	"@timestamp":"2020-09-13T10:48:03.000Z",
 	//	"log.logger":"mylogger",
 	//	"log.origin":{
 	//		"file.name":"main/main.go",
@@ -80,7 +80,7 @@ logger.Error("some error", zap.Error(pkgerrors.Wrap(err, "crash")))
 	// Log Output:
 	//{
 	//	"log.level":"error",
-	//	"@timestamp":1584716847523842,
+	//	"@timestamp":"2020-09-13T10:48:03.000Z",
 	//	"log.logger":"mylogger",
 	//	"log.origin":{
 	//		"file.name":"main/main.go",
@@ -107,7 +107,7 @@ sugar.Infow("some logging info",
 	// Log Output:
 	//{
 	//	"log.level":"info",
-	//	"@timestamp":1584716847523941,
+	//	"@timestamp":"2020-09-13T10:48:03.000Z",
 	//	"log.logger":"mylogger",
 	//	"log.origin":{
 	//		"file.name":"main/main.go",

--- a/core_test.go
+++ b/core_test.go
@@ -35,7 +35,7 @@ func TestCore(t *testing.T) {
 		zap.Error(errors.New("boom")),
 	}
 	assertLogged := func(t *testing.T, out testOutput) {
-		out.requireContains(t, []string{"error", "foo"})
+		out.validate(t, []string{"foo", "error"})
 		outErr, ok := out.m["error"].(map[string]interface{})
 		require.True(t, ok, out.m)
 		assert.Equal(t, map[string]interface{}{"message": "boom"}, outErr)

--- a/encoder_config.go
+++ b/encoder_config.go
@@ -27,7 +27,6 @@ var (
 	defaultEncodeDuration = zapcore.NanosDurationEncoder
 	defaultEncodeLevel    = zapcore.LowercaseLevelEncoder
 	defaultEncodeCaller   = ShortCallerEncoder
-	defaultEncodeTime     = zapcore.ISO8601TimeEncoder
 
 	callerKey     = "log.origin"
 	logLevelKey   = "log.level"
@@ -35,6 +34,7 @@ var (
 	messageKey    = "message"
 	stacktraceKey = "log.origin.stacktrace"
 	timeKey       = "@timestamp"
+	encodeTime    = zapcore.ISO8601TimeEncoder
 )
 
 // EncoderConfig exports all non ECS related configurable settings.
@@ -68,9 +68,6 @@ type EncoderConfig struct {
 	// EncodeCaller defines how an entry caller should be serialized.
 	// It will only be applied if EnableCaller is set to true.
 	EncodeCaller CallerEncoder `json:"callerEncoder" yaml:"callerEncoder"`
-
-	// EncodeTime defines how the log timestamp should be serialized
-	EncodeTime zapcore.TimeEncoder `json:"timeEncoder" yaml:"timeEncoder"`
 }
 
 // NewDefaultEncoderConfig returns an EncoderConfig with default settings.
@@ -94,14 +91,11 @@ func (cfg EncoderConfig) ToZapCoreEncoderConfig() zapcore.EncoderConfig {
 		MessageKey:     messageKey,
 		LevelKey:       logLevelKey,
 		TimeKey:        timeKey,
-		EncodeTime:     cfg.EncodeTime,
+		EncodeTime:     encodeTime,
 		LineEnding:     cfg.LineEnding,
 		EncodeDuration: cfg.EncodeDuration,
 		EncodeName:     cfg.EncodeName,
 		EncodeLevel:    cfg.EncodeLevel,
-	}
-	if encCfg.EncodeTime == nil {
-		encCfg.EncodeTime = defaultEncodeTime
 	}
 	if encCfg.EncodeDuration == nil {
 		encCfg.EncodeDuration = defaultEncodeDuration
@@ -156,10 +150,9 @@ func ECSCompatibleEncoderConfig(cfg zapcore.EncoderConfig) zapcore.EncoderConfig
 		cfg.CallerKey = callerKey
 		cfg.EncodeCaller = defaultEncodeCaller
 	}
+	// always set the time encoding to the ISO8601 time format
+	cfg.EncodeTime = encodeTime
 	// ensure all required encoders are set
-	if cfg.EncodeTime == nil {
-		cfg.EncodeTime = defaultEncodeTime
-	}
 	if cfg.EncodeDuration == nil {
 		cfg.EncodeDuration = defaultEncodeDuration
 	}

--- a/encoder_config_test.go
+++ b/encoder_config_test.go
@@ -38,10 +38,9 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 		expected string
 	}{
 		{name: "defaultConfig",
-			cfg:   NewDefaultEncoderConfig(),
-			input: `{"timeEncoder":"millis"}`,
+			cfg: NewDefaultEncoderConfig(),
 			expected: `{"log.level": "debug",
-						"@timestamp": 1583484083953.468,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
@@ -52,9 +51,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"foo": "bar",
 						"dur": 5000000}`},
 		{name: "defaultUnmarshal",
-			input: `{"timeEncoder":"millis"}`,
 			expected: `{"log.level": "debug",
-						"@timestamp": 1583484083953.468,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"foo": "bar",
 						"dur": 5000000}`},
@@ -63,11 +61,10 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
   					 "enableStacktrace": true,
 					 "enableCaller":true,
 					 "levelEncoder": "upper",
-					 "timeEncoder":"nanos",
 				 	 "durationEncoder": "ms",
 					 "callerEncoder": "short"}`,
 			expected: `{"log.level": "debug",
-						"@timestamp": 1583484083953467800,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
@@ -78,9 +75,9 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"foo": "bar",
 						"dur": 5}`},
 		{name: "fullCaller",
-			input: `{"callerEncoder": "full","enableCaller":true,"timeEncoder":"millis"}`,
+			input: `{"callerEncoder": "full","enableCaller":true}`,
 			expected: `{"log.level": "debug",
-						"@timestamp": 1583484083953.468,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
@@ -93,7 +90,7 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 			// setup
 			entry := zapcore.Entry{
 				Level:      zapcore.DebugLevel,
-				Time:       time.Unix(1583484083, 953467845),
+				Time:       time.Unix(1599994083, 0).UTC(),
 				Message:    "log message",
 				Caller:     caller,
 				Stack:      "stacktrace frames",
@@ -127,9 +124,9 @@ func TestECSCompatibleEncoderConfig(t *testing.T) {
 		expected string
 	}{
 		{name: "empty config",
-			cfg: zapcore.EncoderConfig{EncodeTime: zapcore.EpochTimeEncoder},
+			cfg: zapcore.EncoderConfig{},
 			expected: `{"log.level": "debug",
-						"@timestamp": 1583484083.9534678,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"foo": "bar",
 						"count": 8}`},
@@ -140,7 +137,7 @@ func TestECSCompatibleEncoderConfig(t *testing.T) {
 				NameKey: "replaced nameKey", StacktraceKey: "replaced stacktraceKey",
 				CallerKey: "replaced callerKey", EncodeLevel: zapcore.CapitalLevelEncoder},
 			expected: `{"log.level": "DEBUG",
-						"@timestamp": 1583484083953.468,
+						"@timestamp": "2020-09-13T10:48:03.000Z",
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
@@ -155,7 +152,7 @@ func TestECSCompatibleEncoderConfig(t *testing.T) {
 			// setup
 			entry := zapcore.Entry{
 				Level:      zapcore.DebugLevel,
-				Time:       time.Unix(1583484083, 953467845).UTC(),
+				Time:       time.Unix(1599994083, 0).UTC(),
 				Message:    "log message",
 				Caller:     caller,
 				Stack:      "stacktrace frames",

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// V1 holds the v1 specification
+	V1 *Spec
+)
+
+// Spec holds the fields specified for a spec version
+type Spec struct {
+	URL string `json:"url"`
+	ECS struct {
+		Version string `json:"version"`
+	} `json:"ecs"`
+	Fields map[string]Field `json:"fields"`
+}
+
+// Field contains requirements for a log field
+type Field struct {
+	Comment       Comment      `json:"comment"`
+	Default       string       `json:"default"`
+	Index         *int         `json:"index"`
+	Required      bool         `json:"required"`
+	Sanitization  Sanitization `json:"sanitization"`
+	TopLevelField bool         `json:"top_level_field"`
+	Type          string       `json:"type"`
+	URL           string       `json:"url"`
+}
+
+// Comment is an array of strings
+type Comment []string
+
+// Sanitization defines a substitute for certain substrings
+type Sanitization struct {
+	Key struct {
+		Replacements []string `json:"replacements"`
+		Substitute   string   `json:"substitute"`
+	} `json:"key"`
+}
+
+// RequiredFields returns all fields that are defined as required
+func (s *Spec) RequiredFields() []string {
+	var requiredKeys []string
+	for name, field := range s.Fields {
+		if field.Required {
+			requiredKeys = append(requiredKeys, name)
+		}
+	}
+	return requiredKeys
+}
+
+// UnmarshalJSON unmarshals the given byte into a Comment.
+// Valid values are strings and arrays of strings
+func (c *Comment) UnmarshalJSON(b []byte) error {
+	var comments []string
+	if err := json.Unmarshal(b, &comments); err != nil {
+		var comment string
+		if err := json.Unmarshal(b, &comment); err != nil {
+			return errors.Wrap(err, "unmarshaling comment(s)")
+		}
+		comments = []string{comment}
+	}
+	*c = comments
+	return nil
+}
+
+func init() {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("cannot recover information from runtime.Caller")
+	}
+	f := path.Join(filepath.ToSlash(filepath.Dir(filename)), "v1.json")
+	b, err := ioutil.ReadFile(f)
+	if err != nil {
+		panic(errors.Wrap(err, "reading spec version 1 failed"))
+	}
+	if err := json.Unmarshal(b, &V1); err != nil {
+		panic(errors.Wrap(err, "initializing spec version 1 failed"))
+	}
+}

--- a/internal/spec/v1.json
+++ b/internal/spec/v1.json
@@ -1,0 +1,139 @@
+{
+    "version": 1.0,
+    "url": "https://www.elastic.co/guide/en/ecs/current/index.html",
+    "ecs": {
+        "version": "1.x"
+    },
+    "fields": {
+        "@timestamp": {
+            "type": "datetime",
+            "required": true,
+            "index": 0,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+        },
+        "log.level": {
+            "type": "string",
+            "required": true,
+            "index": 1,
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable.",
+                "Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,",
+                "no matter the number of characters the log level has.",
+                "For example: `'DEBUG'` (5 chars) will not be indented, whereas ` 'WARN'` (4 chars) will be indented by one space character."
+            ]
+        },
+        "message": {
+            "type": "string",
+            "required": true,
+            "index": 2,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+        },
+        "ecs.version": {
+            "type": "string",
+            "required": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
+        },
+        "labels": {
+            "type": "object",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "sanitization": {
+                "key": {
+                    "replacements": [
+                        ".",
+                        "*",
+                        "\\"
+                    ],
+                    "substitute": "_"
+                }
+            }
+        },
+        "trace.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "transaction.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "service.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, they should auto-configure it if not already set."
+            ]
+        },
+        "event.dataset": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
+            "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "comment": [
+                "Configurable by users.",
+                "If the user manually configures the service name,",
+                "the logging library should set `event.dataset=${service.name}.log` if not explicitly configured otherwise.",
+                "",
+                "When agents auto-configure the app to use an ECS logger,",
+                "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
+                "Otherwise, agents should also set `event.dataset=${service.name}.log`",
+                "",
+                "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            ]
+        },
+        "process.thread.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-process.html"
+        },
+        "log.logger": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
+        },
+        "log.origin.file.line": {
+            "type": "integer",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "log.origin.file.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "log.origin.function": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "error.type": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The exception type or class, such as `java.lang.IllegalArgumentException`."
+        },
+        "error.message": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The message of the exception."
+        },
+        "error.stack_trace": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The stack trace of the exception as plain text."
+        }
+    }
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -62,14 +62,14 @@ func (tw *testOutput) validate(t *testing.T, keys ...string) {
 	// skip Default value checks as they are not yet implemented
 	// skip TopLevelField check as ecszap logger logs in dot notation anyways
 	// skip Sanitization as it is not implemented yet
-	for name, val := range tw.m {
-		field, ok := spec.V1.Fields[name]
+	for name, field := range spec.V1.Fields {
+		val, ok := tw.m[name]
+		if field.Required { // all required fields must be present in the log line
+			require.True(t, ok)
+			require.NotNil(t, val)
+		}
 		if !ok { // custom field not defined in spec
 			continue
-		}
-		if field.Required { // all required fields must be present in the log line
-			require.Contains(t, tw.m, name)
-			require.NotNil(t, tw.m[name])
 		}
 		if field.Type != "" { // the defined type must be met
 			var ok bool

--- a/logger_test.go
+++ b/logger_test.go
@@ -20,8 +20,12 @@ package ecszap
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
 	"testing"
+	"time"
 
+	"go.elastic.co/ecszap/internal/spec"
 	"go.uber.org/zap/zapcore"
 
 	errs "github.com/pkg/errors"
@@ -42,9 +46,57 @@ func (tw *testOutput) Write(p []byte) (int, error) {
 
 func (tw *testOutput) Sync() error { return nil }
 
-func (tw *testOutput) requireContains(t *testing.T, keys []string) {
+func (tw *testOutput) validate(t *testing.T, keys []string) {
 	for _, s := range keys {
 		require.Contains(t, tw.m, s)
+	}
+
+	// Fields `log.origin.file.line` and `log.origin.file.name` are logged as
+	// a map under key log.origin. By using the zap jsonEncoder this cannot
+	// be changed. Remove the nested and add a dotted version of the fields
+	if caller, ok := tw.m[callerKey].(map[string]interface{}); ok {
+		for name, val := range caller {
+			tw.m[fmt.Sprintf("%s.%s", callerKey, name)] = val
+			delete(tw.m, name)
+		}
+	}
+	// skip index checks as we do not have control over that with the formatter
+	// skip Default value checks as they are not yet implemented
+	// skip TopLevelField check as ecszap logger logs in dot notation anyways
+	// skip Sanitization as it is not implemented yet
+	for name, val := range tw.m {
+		field, ok := spec.V1.Fields[name]
+		if !ok { // custom field not defined in spec
+			continue
+		}
+		if field.Required { // all required fields must be present in the log line
+			require.Contains(t, tw.m, name)
+			require.NotNil(t, tw.m[name])
+		}
+		if field.Type != "" { // the defined type must be met
+			var ok bool
+			switch field.Type {
+			case "string":
+				_, ok = val.(string)
+			case "datetime":
+				var s string
+				s, ok = val.(string)
+				if _, err := time.Parse("2006-01-02T15:04:05.000Z0700", s); err == nil {
+					ok = true
+				}
+			case "integer":
+				// json.Unmarshal unmarshals into float64 instead of int
+				if _, floatOK := val.(float64); floatOK {
+					_, err := strconv.ParseInt(fmt.Sprintf("%v", val), 10, 64)
+					if err == nil {
+						ok = true
+					}
+				}
+			default:
+				panic(fmt.Errorf("unhandled type %s from specification for field %s", field.Type, name))
+			}
+			require.True(t, ok, fmt.Sprintf("%s: %v", name, val))
+		}
 	}
 }
 
@@ -52,7 +104,7 @@ func (tw *testOutput) reset() {
 	tw.m = make(map[string]interface{})
 }
 
-func TestECSZapLogger_With(t *testing.T) {
+func TestECSZapLogger(t *testing.T) {
 	out := testOutput{}
 
 	for _, tc := range []struct {
@@ -70,20 +122,18 @@ func TestECSZapLogger_With(t *testing.T) {
 			}()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-
 			logger := zap.New(tc.core, zap.AddCaller())
 			defer logger.Sync()
 
 			// strongly typed fields
 			logger.Info("testlog", zap.String("foo", "bar"))
-			out.requireContains(t, []string{"ecs.version", "message",
-				"@timestamp", "log.level", "log.origin", "foo"})
+			out.validate(t, []string{"foo", "log.origin"})
 
 			// log a wrapped error
 			out.reset()
 			err := errors.New("boom")
 			logger.Error("some error", zap.Error(errs.Wrap(err, "crash")))
-			out.requireContains(t, []string{"error"})
+			out.validate(t, []string{"error"})
 
 			// Adding logger wide fields and a logger name
 			out.reset()
@@ -91,7 +141,7 @@ func TestECSZapLogger_With(t *testing.T) {
 			logger = logger.With(zap.Error(errors.New("wrapCore Error")))
 			logger = logger.Named("mylogger")
 			logger.Debug("debug message")
-			out.requireContains(t, []string{"log.logger", "foo", "error"})
+			out.validate(t, []string{"foo", "error"})
 
 			// Use loosely typed logger
 			out.reset()
@@ -100,9 +150,7 @@ func TestECSZapLogger_With(t *testing.T) {
 				"foo", "bar",
 				"count", 17,
 			)
-			out.requireContains(t, []string{"ecs.version", "message",
-				"@timestamp", "log.level", "log.origin", "foo", "count"})
-
+			out.validate(t, []string{"log.origin", "foo", "count"})
 			out.reset()
 
 		})
@@ -115,9 +163,10 @@ func TestECSZapLogger_With(t *testing.T) {
 	logger := zap.New(WrapCore(core), zap.AddCaller())
 	defer logger.Sync()
 	logger.With(zap.Error(errors.New("wrapCore"))).Error("boom")
-	out.requireContains(t, []string{"error", "message"})
+	out.validate(t, []string{"message", "error"})
 	assert.Equal(t, "boom", out.m["message"])
 	outErr, ok := out.m["error"].(map[string]interface{})
+
 	require.True(t, ok, out.m["error"])
 	assert.Equal(t, map[string]interface{}{"message": "wrapCore"}, outErr)
 }


### PR DESCRIPTION
This PR copies the common [spec](https://github.com/elastic/ecs-logging/blob/master/spec/spec.json) for ECS loggers and runs validations for the fields that are already supported. 

The spec itself is just manually copied over, as according to https://github.com/elastic/observability-robots/issues/313 the spec should automatically be synced when changed. 

While on it, a bug was found in the `timestamp` format, where the timestamp can be changed from the default `ISO8601` format to any other format. With this fix the timestamp will always be `ISO8601` for the ECS formatter. 

closes #19 
