### PR TITLE
ci: use gotestsum to generate junit output

### DIFF
--- a/.ci/scripts/run-tests.sh
+++ b/.ci/scripts/run-tests.sh
@@ -6,10 +6,5 @@ eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme 
 
 echo "Run the tests"
 mkdir -p build
-export OUT_FILE='build/test-report.out'
-go test -v ./... | tee ${OUT_FILE}
-
-# To transform the test output to junit and be reported in the CI Jenkins
-echo "Transform test report to JUnit"
-go get -v -u github.com/jstemmer/go-junit-report
-cat "${OUT_FILE}" | go-junit-report > build/junit-report.xml
+go get -v -u gotest.tools/gotestsum
+gotestsum --junitfile build/junit-report.xml -- -v ./...


### PR DESCRIPTION
Change to use [gotestsum](https://pkg.go.dev/gotest.tools/gotestsum/) to generate the tests JUnit output.

closes https://github.com/elastic/ecs-logging-go-zap/issues/13