### PR TITLE
ci: install tools from CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -54,8 +54,10 @@ pipeline {
         withGithubNotify(context: 'Test', tab: 'tests') {
           deleteDir()
           unstash 'source'
-          dir("${BASE_DIR}"){
-            sh script: '.ci/scripts/run-tests.sh', label: 'Run tests'
+          withGoEnv(){
+            dir("${BASE_DIR}"){
+              sh script: '.ci/scripts/run-tests.sh', label: 'Run tests'
+            }
           }
         }
       }

--- a/.ci/scripts/run-tests.sh
+++ b/.ci/scripts/run-tests.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# Install Go
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
-
 echo "Run the tests"
 mkdir -p build
 export OUT_FILE='build/test-report.out'


### PR DESCRIPTION
It uses `withGoEnv` pipeline step to provide a Go environment.