### PR TITLE
ci: use goTestJUnit for run the tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            goTestJUnit(options: '-v ./...', output: 'build/junit-report.xml')
+            goTestJUnit(options: '-v ./...', output: 'junit-report.xml')
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
           unstash 'source'
           withGoEnv(){
             dir("${BASE_DIR}"){
-              sh script: '.ci/scripts/run-tests.sh', label: 'Run tests'
+              goTestJUnit(options: '-v ./...', output: 'build/junit-report.xml')
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -54,10 +54,8 @@ pipeline {
         withGithubNotify(context: 'Test', tab: 'tests') {
           deleteDir()
           unstash 'source'
-          withGoEnv(){
-            dir("${BASE_DIR}"){
-              goTestJUnit(options: '-v ./...', output: 'build/junit-report.xml')
-            }
+          dir("${BASE_DIR}"){
+            goTestJUnit(options: '-v ./...', output: 'build/junit-report.xml')
           }
         }
       }

--- a/.ci/scripts/run-tests.sh
+++ b/.ci/scripts/run-tests.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Run the tests"
-mkdir -p build
-go get -v -u gotest.tools/gotestsum
-gotestsum --junitfile build/junit-report.xml -- -v ./...


### PR DESCRIPTION
It uses a setp in the pipeline library to run the tests and generate the JUnit report, this step internally uses [gotestsum](https://github.com/gotestyourself/gotestsum)