### PR TITLE
Initialize docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ecs-logging-go-zap
 build
+html_docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,16 @@
+:ecs-repo-dir:  {ecs-logging-root}/docs/
+
+include::{docs-root}/shared/versions/stack/current.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/go-zap/current/index.html[elastic.co]
+endif::[]
+
+= ECS Logging Go Zap Reference
+
+ifndef::env-github[]
+include::./introduction.asciidoc[Introduction]
+include::./setup.asciidoc[Set up]
+endif::[]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -1,0 +1,29 @@
+[[intro]]
+== Introduction
+
+beta::[]
+
+ECS loggers are formatter/encoder plugins for your favorite logging libraries.
+They make it easy to format your logs into ECS-compatible JSON.
+
+The encoder logs in JSON format, relying on the default
+https://github.com/uber-go/zap/blob/master/zapcore/json_encoder.go[zapcore/json_encoder] when possible.
+It also handles the logging of error fields in
+https://www.elastic.co/guide/en/ecs/current/ecs-error.html[ECS error format].
+
+By default, the following fields are added:
+
+[source,json]
+----
+{
+  "log.level": "info",
+  "@timestamp": "2020-09-13T10:48:03.000Z",
+  "message":" some logging info",
+  "ecs.version": "1.6.0"
+}
+----
+
+TIP: Want to learn more about ECS, ECS logging, and other available language plugins?
+See the {ecs-logging-ref}/intro.html[ECS logging guide].
+
+Ready to jump into `ecs-logging-go-zap`? <<setup,Get started>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -43,7 +43,6 @@ logger = logger.Named("mylogger")
 logger.Info("some logging info"),
     zap.Int("count", 17),
     zap.Error(errors.New("boom")),
-}
 ----
 
 The example above produces the following log output:

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -40,9 +40,9 @@ logger = logger.With(zap.String("custom", "foo"))
 logger = logger.Named("mylogger")
 
 // Use strongly typed Field values
-logger.Info("some logging info"),
+logger.Info("some logging info",
     zap.Int("count", 17),
-    zap.Error(errors.New("boom")),
+    zap.Error(errors.New("boom")))
 ----
 
 The example above produces the following log output:

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,174 @@
+[[setup]]
+== Get started
+
+[float]
+[[setup-step-1]]
+=== Step 1: Install
+
+Add the package to your `go.mod` file:
+
+[source,go]
+----
+require go.elastic.co/ecszap master
+----
+
+[float]
+[[setup-step-2]]
+=== Step 2: Configure
+
+Set up a default logger. For example:
+
+[source,go]
+----
+encoderConfig := ecszap.NewDefaultEncoderConfig()
+core := ecszap.NewCore(encoderConfig, os.Stdout, zap.DebugLevel)
+logger := zap.New(core, zap.AddCaller())
+----
+
+[float]
+[[examples]]
+=== Examples
+
+[float]
+[[use-structured-logging]]
+==== Use structured logging
+
+[source,go]
+----
+// Add fields and a logger name
+logger = logger.With(zap.String("custom", "foo"))
+logger = logger.Named("mylogger")
+
+// Use strongly typed Field values
+logger.Info("some logging info"),
+    zap.Int("count", 17),
+    zap.Error(errors.New("boom")),
+}
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "log.level": "info",
+  "@timestamp": "2020-09-13T10:48:03.000Z",
+  "log.logger": "mylogger",
+  "log.origin": {
+    "file.name": "main/main.go",
+    "file.line": 265
+  },
+  "message": "some logging info",
+  "ecs.version": "1.6.0",
+  "custom": "foo",
+  "count": 17,
+  "error": {
+    "message":"boom"
+  }
+}
+----
+
+[float]
+[[log-errors]]
+==== Log errors
+
+[source,go]
+----
+err := errors.New("boom")
+logger.Error("some error", zap.Error(pkgerrors.Wrap(err, "crash")))
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "log.level": "error",
+  "@timestamp": "2020-09-13T10:48:03.000Z",
+  "log.logger": "mylogger",
+  "log.origin": {
+    "file.name": "main/main.go",
+    "file.line": 290
+  },
+  "message": "some error",
+  "ecs.version": "1.6.0",
+  "custom": "foo",
+  "error": {
+    "message": "crash: boom",
+    "stack_trace": "\nexample.example\n\t/Users/xyz/example/example.go:50\nruntime.example\n\t/Users/xyz/.gvm/versions/go1.13.8.darwin.amd64/src/runtime/proc.go:203\nruntime.goexit\n\t/Users/xyz/.gvm/versions/go1.13.8.darwin.amd64/src/runtime/asm_amd64.s:1357"
+  }
+}
+----
+
+[float]
+[[use-sugar-logger]]
+==== Use sugar logger
+
+[source,go]
+----
+sugar := logger.Sugar()
+sugar.Infow("some logging info",
+    "foo", "bar",
+    "count", 17,
+)
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "log.level": "info",
+  "@timestamp": "2020-09-13T10:48:03.000Z",
+  "log.logger": "mylogger",
+  "log.origin": {
+    "file.name": "main/main.go",
+    "file.line": 311
+  },
+  "message": "some logging info",
+  "ecs.version": "1.6.0",
+  "custom": "foo",
+  "foo": "bar",
+  "count": 17
+}
+----
+
+[float]
+[[wrap-zapcore]]
+==== Wrap a custom underlying `zapcore.Core`
+
+[source,go]
+----
+encoderConfig := ecszap.NewDefaultEncoderConfig()
+encoder := zapcore.NewJSONEncoder(encoderConfig.ToZapCoreEncoderConfig())
+syslogCore := newSyslogCore(encoder, level) //create your own loggers
+core := ecszap.WrapCore(syslogCore)
+logger := zap.New(core, zap.AddCaller())
+----
+
+[float]
+[[transition-existing]]
+==== Transition from existing configurations
+
+Depending on your needs there are different ways to create the logger:
+
+[source,go]
+----
+encoderConfig := ecszap.ECSCompatibleEncoderConfig(zap.NewDevelopmentEncoderConfig())
+encoder := zapcore.NewJSONEncoder(encoderConfig)
+core := zapcore.NewCore(encoder, os.Stdout, zap.DebugLevel)
+logger := zap.New(ecszap.WrapCore(core), zap.AddCaller())
+----
+
+[source,go]
+----
+config := zap.NewProductionConfig()
+config.EncoderConfig = ecszap.ECSCompatibleEncoderConfig(config.EncoderConfig)
+logger, err := config.Build(ecszap.WrapCoreOption(), zap.AddCaller())
+----
+
+[float]
+[[setup-step-3]]
+=== Step 3: Configure Filebeat
+
+include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]


### PR DESCRIPTION
## Summary

This PR copies the existing `readme.md` documentation into asciidoc format. I have not tested these docs and haven't made any significant changes to them.

## Testing

You can test this PR locally. You'll need an up-to-date copy of [elastic/docs](https://github.com/elastic/docs) and [elastic/ecs-logging](https://github.com/elastic/ecs-logging). Check out this PR and run the following command:

```
$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-go-zap/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1 --open
```

## Related

For https://github.com/elastic/ecs-logging-go-zap/issues/20.
Unblocks https://github.com/elastic/docs/pull/2038.
