### PR TITLE
docs: refer to the project as "ecszap"

### DIFF
--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -26,4 +26,4 @@ By default, the following fields are added:
 TIP: Want to learn more about ECS, ECS logging, and other available language plugins?
 See the {ecs-logging-ref}/intro.html[ECS logging guide].
 
-Ready to jump into `ecs-logging-go-zap`? <<setup,Get started>>.
+Ready to jump into `ecszap`? <<setup,Get started>>.


### PR DESCRIPTION
ecs-logging-go-zap is the repo name, while ecszap is the package name.
Consumers (developers) must import the package as `go.elastic.co/ecszap`,
so I think it probably makes sense to refer to it as "ecszap" in general.