### PR TITLE
When an error already implements zapcore.ObjectMarshaler, don't wrap it with `internal.ecsError`.

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -30,11 +30,16 @@ type ecsError struct {
 }
 
 func NewError(err error) zapcore.ObjectMarshaler {
+	if e, ok := err.(zapcore.ObjectMarshaler); ok {
+		return e
+	}
+
 	return ecsError{err}
 }
 
 func (err ecsError) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("message", err.Error())
+
 	if e, ok := err.error.(stackTracer); ok {
 		enc.AddString("stack_trace", fmt.Sprintf("%+v", e.StackTrace()))
 	}


### PR DESCRIPTION
## Why?

Some errors have more complex structure then just "message" and "stack".
For example we are using [domain errors] that carries fields for an
operator and a developer such as error's code and related fields. The
current encoder implementation keeps only "message".

## What

Passthrough an error at `internal.NewError` when the error already
implemented `zapcore.ObjectMarshaler`.

[domain errors]: https://middlemost.com/failure-is-your-domain/