### PR TITLE
Added "log.origin.function" to caller

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -18,7 +18,6 @@
 package ecszap
 
 import (
-	"runtime"
 	"strings"
 	"time"
 
@@ -66,7 +65,6 @@ func (e *CallerEncoder) UnmarshalText(text []byte) error {
 func encodeCaller(c *caller, enc zapcore.PrimitiveArrayEncoder) {
 	// this function can only be called internally so we have full control over it
 	// and can ensure that enc is always of type zapcore.ArrayEncoder
-	c.Function = runtime.FuncForPC(c.PC).Name()
 	if e, ok := enc.(zapcore.ArrayEncoder); ok {
 		e.AppendObject(c)
 	}

--- a/encoder_config_test.go
+++ b/encoder_config_test.go
@@ -19,7 +19,6 @@ package ecszap
 
 import (
 	"encoding/json"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -32,8 +31,9 @@ import (
 
 func TestJSONEncoder_EncoderConfig(t *testing.T) {
 	path := "/Home/foo/coding/ecszap/json_encoder_test.go"
-	pc, _, _, _ := runtime.Caller(0)
-	caller := zapcore.NewEntryCaller(pc, path, 30, true)
+	caller := zapcore.NewEntryCaller(0, path, 30, true)
+	caller.Function = "FuncName"
+
 	for _, tc := range []struct {
 		name     string
 		cfg      EncoderConfig
@@ -48,7 +48,7 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"log.origin": {
 							"file.line": 30,
 							"file.name": "ecszap/json_encoder_test.go",
-							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
+							"function": "FuncName"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",
@@ -83,7 +83,7 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"log.origin": {
 							"file.line": 30,
 							"file.name": "ecszap/json_encoder_test.go",
-							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
+							"function": "FuncName"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ecs",
@@ -108,7 +108,7 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"log.origin": {
 							"file.line": 30,
 							"file.name": "ecszap/json_encoder_test.go",
-							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
+							"function": "FuncName"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",
@@ -122,7 +122,7 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"log.origin": {
 							"file.line": 30,
 							"file.name": "/Home/foo/coding/ecszap/json_encoder_test.go",
-							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
+							"function": "FuncName"
 						},
 						"foo": "bar",
 						"dur": 5000000}`},
@@ -158,8 +158,9 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 
 func TestECSCompatibleEncoderConfig(t *testing.T) {
 	path := "/Home/foo/coding/ecszap/json_encoder_test.go"
-	pc, _, _, _ := runtime.Caller(0)
-	caller := zapcore.NewEntryCaller(pc, path, 30, true)
+	caller := zapcore.NewEntryCaller(0, path, 30, true)
+	caller.Function = "FuncName"
+
 	for _, tc := range []struct {
 		name     string
 		cfg      zapcore.EncoderConfig
@@ -184,7 +185,7 @@ func TestECSCompatibleEncoderConfig(t *testing.T) {
 						"log.origin": {
 							"file.line": 30,
 							"file.name": "ecszap/json_encoder_test.go",
-							"function": "go.elastic.co/ecszap.TestECSCompatibleEncoderConfig"
+							"function": "FuncName"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",

--- a/encoder_config_test.go
+++ b/encoder_config_test.go
@@ -19,6 +19,7 @@ package ecszap
 
 import (
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +32,8 @@ import (
 
 func TestJSONEncoder_EncoderConfig(t *testing.T) {
 	path := "/Home/foo/coding/ecszap/json_encoder_test.go"
-	caller := zapcore.NewEntryCaller(0, path, 30, true)
+	pc, _, _, _ := runtime.Caller(0)
+	caller := zapcore.NewEntryCaller(pc, path, 30, true)
 	for _, tc := range []struct {
 		name     string
 		cfg      EncoderConfig
@@ -45,7 +47,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
-							"file.name": "ecszap/json_encoder_test.go"
+							"file.name": "ecszap/json_encoder_test.go",
+							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",
@@ -79,7 +82,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
-							"file.name": "ecszap/json_encoder_test.go"
+							"file.name": "ecszap/json_encoder_test.go",
+							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ecs",
@@ -103,7 +107,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
-							"file.name": "ecszap/json_encoder_test.go"
+							"file.name": "ecszap/json_encoder_test.go",
+							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",
@@ -116,7 +121,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
-							"file.name": "/Home/foo/coding/ecszap/json_encoder_test.go"
+							"file.name": "/Home/foo/coding/ecszap/json_encoder_test.go",
+							"function": "go.elastic.co/ecszap.TestJSONEncoder_EncoderConfig"
 						},
 						"foo": "bar",
 						"dur": 5000000}`},
@@ -152,7 +158,8 @@ func TestJSONEncoder_EncoderConfig(t *testing.T) {
 
 func TestECSCompatibleEncoderConfig(t *testing.T) {
 	path := "/Home/foo/coding/ecszap/json_encoder_test.go"
-	caller := zapcore.NewEntryCaller(0, path, 30, true)
+	pc, _, _, _ := runtime.Caller(0)
+	caller := zapcore.NewEntryCaller(pc, path, 30, true)
 	for _, tc := range []struct {
 		name     string
 		cfg      zapcore.EncoderConfig
@@ -176,7 +183,8 @@ func TestECSCompatibleEncoderConfig(t *testing.T) {
 						"message": "log message",
 						"log.origin": {
 							"file.line": 30,
-							"file.name": "ecszap/json_encoder_test.go"
+							"file.name": "ecszap/json_encoder_test.go",
+							"function": "go.elastic.co/ecszap.TestECSCompatibleEncoderConfig"
 						},
 						"log.origin.stack_trace": "frames",
 						"log.logger": "ECS",

--- a/logger_test.go
+++ b/logger_test.go
@@ -127,6 +127,11 @@ func TestECSZapLogger(t *testing.T) {
 			logger.Info("testlog", zap.String("foo", "bar"))
 			out.validate(t, "foo", "log.origin")
 
+			// caller function
+			outLogOrigin, ok := out.m["log.origin"].(map[string]interface{})
+			require.True(t, ok, out.m["log.origin"])
+			require.Contains(t, outLogOrigin["function"], "ecszap.TestECSZapLogger")
+
 			// log a wrapped error
 			out.reset()
 			logger.With(zap.Error(errors.New("test error"))).Error("boom")


### PR DESCRIPTION
This adds the ECS standard "log.origin.function" field to the caller fields, alongside "log.origin.file.line" and "log.origin.file.name".