### PR TITLE
synchronize ecs-logging spec

### DIFF
--- a/internal/spec/v1.json
+++ b/internal/spec/v1.json
@@ -42,7 +42,12 @@
         "ecs.version": {
             "type": "string",
             "required": true,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable."
+            ]
         },
         "labels": {
             "type": "object",


### PR DESCRIPTION
### What

ECS logging specs automatic sync

### Why

*Changeset*
* https://github.com/elastic/ecs-logging/commit/438fc2c Ensure ecs.version is treated as a top level field (https://github.com/elastic/ecs-logging/pull/71)