### PR TITLE
test: always set entry timestamp

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -20,6 +20,7 @@ package ecszap
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestCore(t *testing.T) {
-	entry := zapcore.Entry{Level: zapcore.DebugLevel}
+	entry := zapcore.Entry{Time: time.Now(), Level: zapcore.DebugLevel}
 	fields := []zapcore.Field{
 		zap.String("foo", "bar"),
 		zap.Error(errors.New("boom")),

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -19,7 +19,7 @@ package spec
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -96,7 +96,7 @@ func init() {
 		panic("cannot recover information from runtime.Caller")
 	}
 	f := path.Join(filepath.ToSlash(filepath.Dir(filename)), "v1.json")
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		panic(errors.Wrap(err, "reading spec version 1 failed"))
 	}


### PR DESCRIPTION
In new versions of zap the entry timestamp is only logged if not zero.

To avoid test failure on recent versions, always set the entry timestamp.

Should unblock https://github.com/elastic/ecs-logging-go-zap/pull/71