### PR TITLE
test: always set entry timestamp

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -61,7 +61,11 @@ func TestCore(t *testing.T) {
 	t.Run("Check", func(t *testing.T) {
 		out := testOutput{}
 		c := NewCore(NewDefaultEncoderConfig(), &out, zap.DebugLevel)
-		ce := c.Check(entry, &zapcore.CheckedEntry{})
+		ce := c.Check(entry, &zapcore.CheckedEntry{
+			Entry: zapcore.Entry{
+				Time: time.Now(),
+			},
+		})
 		ce.Write(fields...)
 		assertLogged(t, out)
 	})


### PR DESCRIPTION
Same as https://github.com/elastic/ecs-logging-go-zap/pull/75